### PR TITLE
Change "guidelines" link

### DIFF
--- a/src/testing/doc_testing.md
+++ b/src/testing/doc_testing.md
@@ -70,7 +70,7 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 The main purpose of documentation tests is to serve as examples that exercise
 the functionality, which is one of the most important
-[guidelines][question-instead-of-unwrap]. It allows using examples from docs as
+[guidelines][all-items-have-a-rustdoc-example]. It allows using examples from docs as
 complete code snippets. But using `?` makes compilation fail since `main`
 returns `unit`. The ability to hide some source lines from documentation comes
 to the rescue: one may write `fn try_main() -> Result<(), ErrorType>`, hide it and
@@ -107,4 +107,4 @@ pub fn try_div(a: i32, b: i32) -> Result<i32, String> {
 [doc-nursery]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html
 [markdown]: https://daringfireball.net/projects/markdown/
 [RFC505]: https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-conventions.md
-[question-instead-of-unwrap]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark
+[all-items-have-a-rustdoc-example]: https://rust-lang.github.io/api-guidelines/documentation.html#all-items-have-a-rustdoc-example-c-example


### PR DESCRIPTION
The "guidelines" link is intended to point to information encouraging the use of examples in documentation, but actually links to the section following this information.